### PR TITLE
Fix `.env` variables not being imported and therefor unable to be used.

### DIFF
--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -30,6 +30,15 @@ elif [ "$MACHINE" == "mac" ]; then
     SEDCMD="sed -i \".bak\""
 fi
 
+if [ ! -f .env ]; then
+    echo "No .env file found within current working directory $(pwd)"
+    echo "Create a .env file before running ./vessel"
+    exit 0
+fi
+
+# Import variables from .env
+source .env
+
 export APP_PORT=${APP_PORT:-80}
 export MYSQL_PORT=${MYSQL_PORT:-3306}
 
@@ -58,13 +67,6 @@ if [ $# -gt 0 ]; then
         else
             echo "VESSEL: Installing Predis"
             $COMPOSER require predis/predis
-        fi
-
-
-        if [ ! -f .env ]; then
-            echo "No .env file found within current working directory $(pwd)"
-            echo "Create a .env file before re-initializing"
-            exit 0
         fi
 
         echo "VESSEL: Setting .env Variables"


### PR DESCRIPTION
Maybe I'm missing something, but it seems to me that the variables defined within `.env` are also required to be imported into the `vessel` command.

They are used if you are overriding the default ports for `APP_PORT` and `MYSQL_PORT`. They also seem to be required by the `dump` command.

Please let me know if I am mistaken somehow.