### PR TITLE
Linuxperms

### DIFF
--- a/docker-files/docker-compose.yml
+++ b/docker-files/docker-compose.yml
@@ -21,7 +21,6 @@ services:
       dockerfile: Dockerfile
       args:
         uid: "${WWWUSER}"
-        gid: "${WWWGROUP}"
     image: vessel/node
     user: node
     volumes:

--- a/docker-files/docker-compose.yml
+++ b/docker-files/docker-compose.yml
@@ -19,8 +19,11 @@ services:
     build:
       context: ./docker/node
       dockerfile: Dockerfile
+      args:
+        uid: "${WWWUSER}"
+        gid: "${WWWGROUP}"
     image: vessel/node
-    user: "${WWWUSER}"
+    user: node
     volumes:
      - .:/var/www/html
     networks:

--- a/docker-files/docker-compose.yml
+++ b/docker-files/docker-compose.yml
@@ -9,7 +9,8 @@ services:
      - "${APP_PORT}:80"
     environment:
       CONTAINER_ENV: "${APP_ENV}"
-      XDEBUG_HOST: ${XDEBUG_HOST}
+      XDEBUG_HOST: "${XDEBUG_HOST}"
+      WWWUSER: "${WWWUSER}"
     volumes:
      - .:/var/www/html
     networks:

--- a/docker-files/docker-compose.yml
+++ b/docker-files/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       context: ./docker/node
       dockerfile: Dockerfile
     image: vessel/node
+    user: "${WWWUSER}"
     volumes:
      - .:/var/www/html
     networks:

--- a/docker-files/docker/app/Dockerfile
+++ b/docker-files/docker/app/Dockerfile
@@ -33,5 +33,3 @@ COPY start-container /usr/local/bin/start-container
 RUN chmod +x usr/local/bin/start-container
 
 ENTRYPOINT ["start-container"]
-
-RUN chown -R www-data: /var/www/html

--- a/docker-files/docker/app/Dockerfile
+++ b/docker-files/docker/app/Dockerfile
@@ -30,6 +30,6 @@ EXPOSE 80
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY start-container /usr/local/bin/start-container
-RUN chmod +x usr/local/bin/start-container
+RUN chmod +x /usr/local/bin/start-container
 
 ENTRYPOINT ["start-container"]

--- a/docker-files/docker/app/start-container
+++ b/docker-files/docker/app/start-container
@@ -25,6 +25,10 @@ fi
 # Config /etc/php/7.1/mods-available/xdebug.ini
 sed -i "s/xdebug\.remote_host\=.*/xdebug\.remote_host\=$XDEBUG_HOST/g" /etc/php/7.1/mods-available/xdebug.ini
 
+# Run PHP-FPM as current user
+if [ ! -z "$WWWUSER" ]; then
+    sed -i "s/user\ \=.*/user\ \= $WWWUSER/g" /etc/php/7.1/fpm/pool.d/www.conf
+fi
 
 if [ $# -gt 0 ];then
     # If we passed a command, run it

--- a/docker-files/docker/app/start-container
+++ b/docker-files/docker/app/start-container
@@ -8,6 +8,11 @@ if [ ! "production" == "$APP_ENV" ] && [ ! "prod" == "$APP_ENV" ]; then
 
     ## CLI
     ln -sf /etc/php/7.1/mods-available/xdebug.ini /etc/php/7.1/cli/conf.d/20-xdebug.ini
+
+    # Run PHP-FPM as current user
+    if [ ! -z "$WWWUSER" ]; then
+        sed -i "s/user\ \=.*/user\ \= $WWWUSER/g" /etc/php/7.1/fpm/pool.d/www.conf
+    fi
 else
     # Disable xdebug
 
@@ -24,11 +29,6 @@ fi
 
 # Config /etc/php/7.1/mods-available/xdebug.ini
 sed -i "s/xdebug\.remote_host\=.*/xdebug\.remote_host\=$XDEBUG_HOST/g" /etc/php/7.1/mods-available/xdebug.ini
-
-# Run PHP-FPM as current user
-if [ ! -z "$WWWUSER" ]; then
-    sed -i "s/user\ \=.*/user\ \= $WWWUSER/g" /etc/php/7.1/fpm/pool.d/www.conf
-fi
 
 if [ $# -gt 0 ];then
     # If we passed a command, run it

--- a/docker-files/docker/node/Dockerfile
+++ b/docker-files/docker/node/Dockerfile
@@ -6,4 +6,6 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && apt-get install -y git yarn \
     && apt-get -y autoremove \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && mkdir /.config /.cache \
+    && chmod ugo+rwx /.config /.cache

--- a/docker-files/docker/node/Dockerfile
+++ b/docker-files/docker/node/Dockerfile
@@ -1,11 +1,14 @@
 FROM node:latest
 
+ARG uid=999
+ARG gid=999
+
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb http://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
     && apt-get update \
     && apt-get install -y git yarn \
     && apt-get -y autoremove \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && mkdir /.config /.cache \
-    && chmod ugo+rwx /.config /.cache
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN groupmod -g $gid node && usermod -u $uid -g $gid node

--- a/docker-files/docker/node/Dockerfile
+++ b/docker-files/docker/node/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:latest
 
 ARG uid=999
-ARG gid=999
 
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb http://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
@@ -11,4 +10,5 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN groupmod -g $gid node && usermod -u $uid -g $gid node
+
+RUN usermod -u $uid node

--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -33,7 +33,6 @@ fi
 export APP_PORT=${APP_PORT:-80}
 export MYSQL_PORT=${MYSQL_PORT:-3306}
 export WWWUSER=${WWWUSER:-$UID}
-export WWWGROUP=${WWWGROUP:-$GID}
 
 # Is the environment running
 PSRESULT="$(docker-compose ps -q)"

--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -33,6 +33,7 @@ fi
 export APP_PORT=${APP_PORT:-80}
 export MYSQL_PORT=${MYSQL_PORT:-3306}
 export WWWUSER=${WWWUSER:-$UID}
+export WWWGROUP=${WWWGROUP:-$GID}
 
 # Is the environment running
 PSRESULT="$(docker-compose ps -q)"

--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -32,6 +32,7 @@ fi
 
 export APP_PORT=${APP_PORT:-80}
 export MYSQL_PORT=${MYSQL_PORT:-3306}
+export WWWUSER=${WWWUSER:-$UID}
 
 # Is the environment running
 PSRESULT="$(docker-compose ps -q)"
@@ -41,7 +42,7 @@ else
     EXEC="no"
 fi
 
-# Create bae docker-compose command to run
+# Create base docker-compose command to run
 COMPOSE="docker-compose -f docker-compose.yml"
 
 # If we pass any arguments...

--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -70,11 +70,14 @@ if [ $# -gt 0 ]; then
 
         echo "VESSEL: Setting .env Variables"
         cp .env .env.vessel
-        $SEDCMD -i ".bak" "s/DB_HOST=.*/DB_HOST=mysql/" .env
-        $SEDCMD -i ".bak" "s/CACHE_DRIVER=.*/CACHE_DRIVER=redis/" .env
-        $SEDCMD -i ".bak" "s/SESSION_DRIVER=.*/SESSION_DRIVER=redis/" .env
-        $SEDCMD -i ".bak" "s/REDIS_HOST=.*/REDIS_HOST=redis/" .env
-        rm .env.bak
+        $SEDCMD "s/DB_HOST=.*/DB_HOST=mysql/" .env
+        $SEDCMD "s/CACHE_DRIVER=.*/CACHE_DRIVER=redis/" .env
+        $SEDCMD "s/SESSION_DRIVER=.*/SESSION_DRIVER=redis/" .env
+        $SEDCMD "s/REDIS_HOST=.*/REDIS_HOST=redis/" .env
+
+        if [ -f .env.bak ]; then
+            rm .env.bak
+        fi
 
         if [ ! -f vessel ]; then
             echo "No vessel file found within current working directory $(pwd)"


### PR DESCRIPTION
Linux permissions settled for App and Node containers, both of which create and edit files shared with the host file system.

## App Container

The app container will dynamically set PHP-FPM to run as the same UID as the host machine's current user. This lets PHP write to the cache, log (etc) files as needed for local development.

## Node Container

The Node container comes with a user `node`. We run the container as user `node`. At build time (when the `Dockerfile` is read to build the Node image), the UID of the `node` user is set to the UID of the current user. Then when the container is run as user `node`, it will also match the UID of the current user (just like the App container). 

This can't be done dynamically at run time as easily in the Node container, so it's done at build time.