### PR TITLE
Remove the instruction to use the .env file for setting APP_PORT or M…

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,7 @@ Head to `http://localhost` in your browser and see your Laravel site!
 
 Vessel attempts to bind to port 80 and 3306 on your machine, so you can simply go to `http://localhost` in your browser.
 
-However, if you run more than one instance of Vessel, you'll get an error when starting it; Each port can only be used once. To get around this, use a different port per project by setting the `APP_PORT` and `MYSQL_PORT` environment variables in one of two ways:
-
-Within the `.env` file:
-
-```
-APP_PORT=8080
-MYSQL_PORT=33060
-```
-
-Or when starting Vessel:
+However, if you run more than one instance of Vessel, you'll get an error when starting it; Each port can only be used once. To get around this, use a different port per project by setting the `APP_PORT` and `MYSQL_PORT` environment variables when starting Vessel:
 
 ```bash
 APP_PORT=8080 MYSQL_PORT=33060 ./vessel start


### PR DESCRIPTION
Considering these two lines override and make adding `APP_PORT` or `MYSQL_PORT` to the `.env` file redundant, this PR removes them from the instructions.