### PR TITLE
Pass docker env variables to php-fpm

### DIFF
--- a/docker-files/docker/app/php-fpm.conf
+++ b/docker-files/docker/app/php-fpm.conf
@@ -123,3 +123,8 @@ daemonize = no
 ;  - the global prefix if it's been set (-p argument)
 ;  - /usr otherwise
 include=/etc/php/7.1/fpm/pool.d/*.conf
+
+; Clear environment in FPM workers. Prevents arbitrary environment variables from
+; reaching FPM worker processes by clearing the environment in workers before env
+; vars specified in this pool configuration are added.
+clear_env=false


### PR DESCRIPTION
Set clear_env to false in php-fpm to allow env variables set on the docker container (eg. through the docker-compose file) to be passed into php-fpm.