### PR TITLE
Mac SED Tweak

### DIFF
--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -27,7 +27,7 @@ elif [ "$MACHINE" == "mac" ]; then
         export XDEBUG_HOST=$(ipconfig getifaddr en1) # Wifi
     fi
 
-    SEDCMD="sed -i \".bak\""
+    SEDCMD="sed -i .bak"
 fi
 
 export APP_PORT=${APP_PORT:-80}


### PR DESCRIPTION
This is happening with sed with quotes

<img width="709" alt="captura de tela 2017-10-20 as 01 05 38" src="https://user-images.githubusercontent.com/347400/31803564-3348c33a-b533-11e7-8ea4-c84ade545c33.png">

Removing quotes from `sed` command properly generates `.env.bak` file and gets deleted properly later on..