### PR TITLE
Tell Docker to run as system user for app-container CLI commands

### DIFF
--- a/docker-files/docker/app/Dockerfile
+++ b/docker-files/docker/app/Dockerfile
@@ -2,6 +2,19 @@ FROM ubuntu:16.04
 
 MAINTAINER Chris Fidao
 
+ENV GOSU_VERSION 1.7
+RUN set -x \
+    && apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
+    && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+    && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+    && export GNUPGHOME="$(mktemp -d)" \
+    && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+    && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+    && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+    && chmod +x /usr/local/bin/gosu \
+    && gosu nobody true \
+    && apt-get purge -y --auto-remove ca-certificates wget
+
 RUN echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu xenial main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && echo "deb http://ppa.launchpad.net/nginx/development/ubuntu xenial main" > /etc/apt/sources.list.d/ppa_nginx_mainline.list \
     && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E5267A6C \

--- a/docker-files/docker/app/start-container
+++ b/docker-files/docker/app/start-container
@@ -1,38 +1,23 @@
 #!/usr/bin/env bash
 
-if [ ! "production" == "$APP_ENV" ] && [ ! "prod" == "$APP_ENV" ]; then
-    # Enable xdebug
-
-    ## FPM
-    ln -sf /etc/php/7.1/mods-available/xdebug.ini /etc/php/7.1/fpm/conf.d/20-xdebug.ini
-
-    ## CLI
-    ln -sf /etc/php/7.1/mods-available/xdebug.ini /etc/php/7.1/cli/conf.d/20-xdebug.ini
-
-    # Run PHP-FPM as current user
-    if [ ! -z "$WWWUSER" ]; then
-        sed -i "s/user\ \=.*/user\ \= $WWWUSER/g" /etc/php/7.1/fpm/pool.d/www.conf
-    fi
-else
-    # Disable xdebug
-
-    ## FPM
-    if [ -e /etc/php/7.1/fpm/conf.d/20-xdebug.ini ]; then
-        rm -f /etc/php/7.1/fpm/conf.d/20-xdebug.ini
-    fi
-
-    ## CLI
-    if [ -e /etc/php/7.1/cli/conf.d/20-xdebug.ini ]; then
-        rm -f /etc/php/7.1/cli/conf.d/20-xdebug.ini
-    fi
-fi
-
 # Config /etc/php/7.1/mods-available/xdebug.ini
 sed -i "s/xdebug\.remote_host\=.*/xdebug\.remote_host\=$XDEBUG_HOST/g" /etc/php/7.1/mods-available/xdebug.ini
 
+# Run PHP-FPM as current user
+if [ ! -z "$WWWUSER" ]; then
+    sed -i "s/user\ \=.*/user\ \= $WWWUSER/g" /etc/php/7.1/fpm/pool.d/www.conf
+fi
+
+# Ensure /.composer exists and is writable
+if [ ! -d /.composer ]; then
+    mkdir /.composer
+fi
+chmod -R ugo+rw /.composer
+
+# Run a command or supervisord
 if [ $# -gt 0 ];then
-    # If we passed a command, run it
-    exec "$@"
+    # If we passed a command, run it as current user
+    exec gosu $WWWUSER "$@"
 else
     # Otherwise start supervisord
     /usr/bin/supervisord

--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -117,7 +117,9 @@ if [ $# -gt 0 ]; then
     elif [ "$1" == "artisan" ] || [ "$1" == "art" ]; then
         shift 1
         if [ "$EXEC" == "yes" ]; then
-            $COMPOSE exec app \
+            $COMPOSE exec \
+                -u $WWWUSER \
+                app \
                 sh -c "cd /var/www/html && php artisan `echo "$@"`"
         else
             $COMPOSE run --rm \
@@ -131,7 +133,9 @@ if [ $# -gt 0 ]; then
     elif [ "$1" == "composer" ] || [ "$1" == "comp" ]; then
         shift 1
         if [ "$EXEC" == "yes" ]; then
-            $COMPOSE exec app \
+            $COMPOSE exec \
+                -u $WWWUSER \
+                app \
                 sh -c "cd /var/www/html && composer `echo "$@"`"
         else
             $COMPOSE run --rm \
@@ -145,7 +149,9 @@ if [ $# -gt 0 ]; then
     elif [ "$1" == "test" ]; then
         shift 1
         if [ "$EXEC" == "yes" ]; then
-            $COMPOSE exec app \
+            $COMPOSE exec \
+                -u $WWWUSER \
+                app \
                 sh -c "cd /var/www/html && ./vendor/bin/phpunit `echo "$@"`"
         else
             $COMPOSE run --rm \

--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -118,10 +118,12 @@ if [ $# -gt 0 ]; then
         shift 1
         if [ "$EXEC" == "yes" ]; then
             $COMPOSE exec app \
+                -u $WWWUSER \
                 sh -c "cd /var/www/html && php artisan `echo "$@"`"
         else
             $COMPOSE run --rm \
                 -w /var/www/html \
+                -u $WWWUSER \
                 app \
                 php artisan "$@"
         fi
@@ -132,10 +134,12 @@ if [ $# -gt 0 ]; then
         shift 1
         if [ "$EXEC" == "yes" ]; then
             $COMPOSE exec app \
+                -u $WWWUSER \
                 sh -c "cd /var/www/html && composer `echo "$@"`"
         else
             $COMPOSE run --rm \
                 -w /var/www/html \
+                -u $WWWUSER \
                 app \
                 composer "$@"
         fi
@@ -146,10 +150,12 @@ if [ $# -gt 0 ]; then
         shift 1
         if [ "$EXEC" == "yes" ]; then
             $COMPOSE exec app \
+                -u $WWWUSER \
                 sh -c "cd /var/www/html && ./vendor/bin/phpunit `echo "$@"`"
         else
             $COMPOSE run --rm \
                 -w /var/www/html \
+                -u $WWWUSER \
                 app \
                 ./vendor/bin/phpunit "$@"
         fi

--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -118,12 +118,10 @@ if [ $# -gt 0 ]; then
         shift 1
         if [ "$EXEC" == "yes" ]; then
             $COMPOSE exec app \
-                -u $WWWUSER \
                 sh -c "cd /var/www/html && php artisan `echo "$@"`"
         else
             $COMPOSE run --rm \
                 -w /var/www/html \
-                -u $WWWUSER \
                 app \
                 php artisan "$@"
         fi
@@ -134,12 +132,10 @@ if [ $# -gt 0 ]; then
         shift 1
         if [ "$EXEC" == "yes" ]; then
             $COMPOSE exec app \
-                -u $WWWUSER \
                 sh -c "cd /var/www/html && composer `echo "$@"`"
         else
             $COMPOSE run --rm \
                 -w /var/www/html \
-                -u $WWWUSER \
                 app \
                 composer "$@"
         fi
@@ -150,12 +146,10 @@ if [ $# -gt 0 ]; then
         shift 1
         if [ "$EXEC" == "yes" ]; then
             $COMPOSE exec app \
-                -u $WWWUSER \
                 sh -c "cd /var/www/html && ./vendor/bin/phpunit `echo "$@"`"
         else
             $COMPOSE run --rm \
                 -w /var/www/html \
-                -u $WWWUSER \
                 app \
                 ./vendor/bin/phpunit "$@"
         fi


### PR DESCRIPTION
Fixing #15, telling Docker what user to run CLI commands as for php-based commands in the app container.

This ideally is dynamic per call rather than built into the `Dockerfile` for portability.