### PR TITLE
Fallback to docker if composer is not present on the local machine

### DIFF
--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -60,14 +60,16 @@ if [ $# -gt 0 ]; then
         echo "VESSEL: Initializing Vessel..."
         COMPOSER=$(which composer)
         if [ -z "$COMPOSER" ]; then
-            echo "No composer command found"
-            echo "Please install composer package predis/predis before re-initializing"
-            exit 0
-        else
-            echo "VESSEL: Installing Predis"
-            $COMPOSER require predis/predis
+          USER_ID=$(id -u -r)
+
+          COMPOSER="docker run -u $USER_ID --rm -it \
+            -v $(pwd):/opt/${PWD##*/} \
+            -w /opt/${PWD##*/} shippingdocker/php-composer:latest \
+            composer require predis/predis"
         fi
 
+        echo "VESSEL: Installing Predis"
+        $COMPOSER require predis/predis
 
         if [ ! -f .env ]; then
             echo "No .env file found within current working directory $(pwd)"


### PR DESCRIPTION
Hey there @shippingdocker :) first of all, thanks for Vessel. I really like how it makes things simple.

I noticed a strange thing and I wanted to fix it.

I tried to reproduce all the steps in order to prepare everything without locally installed PHP & Composer. 

However, if you go through all the steps as explained in the docs, once you arrive to the `bash vessel init` you get a "No composer command found" because there isn't a fallback to docker while trying to get initialize `COMPOSER` variable in the bash file.

Here's a fix proposal: if `COMPOSER` value cannot be resolved via `which`, the fallback is a `docker run` and everything works normally.

Let me know what do you think about this :)