### PR TITLE
Change MAINTAINER to LABEL due to deprecation.  

### DIFF
--- a/docker-files/docker/app/Dockerfile
+++ b/docker-files/docker/app/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-MAINTAINER Chris Fidao
+LABEL maintainer="Chris Fidao"
 
 ENV GOSU_VERSION 1.7
 RUN set -x \


### PR DESCRIPTION
# MAINTAINER (deprecated)
* See https://docs.docker.com/engine/reference/builder/#maintainer-deprecated