### PR TITLE
Windows support for Git Bash and WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,12 +168,13 @@ If you want to see how this workflow was developed, check out [Shipping Docker](
 
 ## Supported Systems
 
-Vessel requires Docker, and currently only works on Mac and Linux.
+Vessel requires Docker, and currently only works on Windows, Mac and Linux.
 
-> Window support may come in the future. It will require running Hyper-V.
+> Windows requires running Hyper-V.  Using Git Bash (MINGW64) and WSL are supported.  Native
+  Windows is still under development.
 
 | Mac           | Linux         | Windows |
 | ------------- |:-------------:|:-------:|
-| Install Docker on [Mac](https://docs.docker.com/docker-for-mac/install/) | Install Docker on [Debian](https://docs.docker.com/engine/installation/linux/docker-ce/debian/) | Not Currently Supported |
+| Install Docker on [Mac](https://docs.docker.com/docker-for-mac/install/) | Install Docker on [Debian](https://docs.docker.com/engine/installation/linux/docker-ce/debian/) | Install Docker on [Windows] (https://docs.docker.com/docker-for-windows/install/) |
 |       | Install Docker on [Ubuntu](https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/) | |
 |       | Install Docker on [CentOS](https://docs.docker.com/engine/installation/linux/docker-ce/centos/) | |

--- a/README.md
+++ b/README.md
@@ -175,6 +175,6 @@ Vessel requires Docker, and currently only works on Windows, Mac and Linux.
 
 | Mac           | Linux         | Windows |
 | ------------- |:-------------:|:-------:|
-| Install Docker on [Mac](https://docs.docker.com/docker-for-mac/install/) | Install Docker on [Debian](https://docs.docker.com/engine/installation/linux/docker-ce/debian/) | Install Docker on [Windows] (https://docs.docker.com/docker-for-windows/install/) |
+| Install Docker on [Mac](https://docs.docker.com/docker-for-mac/install/) | Install Docker on [Debian](https://docs.docker.com/engine/installation/linux/docker-ce/debian/) | Install Docker on [Windows](https://docs.docker.com/docker-for-windows/install/) |
 |       | Install Docker on [Ubuntu](https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/) | |
 |       | Install Docker on [CentOS](https://docs.docker.com/engine/installation/linux/docker-ce/centos/) | |

--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -31,8 +31,10 @@ elif [ "$MACHINE" == "mac" ]; then
     if [ -z "$XDEBUG_HOST" ]; then
         export XDEBUG_HOST=$(ipconfig getifaddr en1) # Wifi
     fi
-
     SEDCMD="sed -i .bak"
+elif [ "$MACHINE" == "mingw64" ]; then
+    export XDEBUG_HOST=10.0.75.1
+    SEDCMD="sed -i"
 fi
 
 export APP_PORT=${APP_PORT:-80}

--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -2,14 +2,15 @@
 
 UNAMEOUT="$(uname -s)"
 case "${UNAMEOUT}" in
-    Linux*)     MACHINE=linux;;
-    Darwin*)    MACHINE=mac;;
-    *)          MACHINE="UNKNOWN"
+    Linux*)             MACHINE=linux;;
+    Darwin*)            MACHINE=mac;;
+    MINGW64_NT-10.0*)   MACHINE=mingw64;;
+    *)                  MACHINE="UNKNOWN"
 esac
 
 if [ "$MACHINE" == "UNKNOWN" ]; then
     echo "Unsupported system type"
-    echo "System must be a Macintosh or Linux"
+    echo "System must be a Macintosh, Linux or Windows"
     echo ""
     echo "System detection determined via uname command"
     echo "If the following is empty, could not find uname command: $(which uname)"
@@ -18,7 +19,11 @@ fi
 
 # Set environment variables for dev
 if [ "$MACHINE" == "linux" ]; then
-    export XDEBUG_HOST=$(/sbin/ifconfig docker0 | grep "inet addr" | cut -d ':' -f 2 | cut -d ' ' -f 1)
+    if grep -q Microsoft /proc/version; then
+        export XDEBUG_HOST=10.0.75.1
+    else
+        export XDEBUG_HOST=$(/sbin/ifconfig docker0 | grep "inet addr" | cut -d ':' -f 2 | cut -d ' ' -f 1)
+    fi
     SEDCMD="sed -i"
 elif [ "$MACHINE" == "mac" ]; then
     export XDEBUG_HOST=$(ipconfig getifaddr en0) # Ethernet

--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -19,7 +19,7 @@ fi
 
 # Set environment variables for dev
 if [ "$MACHINE" == "linux" ]; then
-    if grep -q Microsoft /proc/version; then
+    if grep -q Microsoft /proc/version; then # WSL
         export XDEBUG_HOST=10.0.75.1
     else
         export XDEBUG_HOST=$(/sbin/ifconfig docker0 | grep "inet addr" | cut -d ':' -f 2 | cut -d ' ' -f 1)
@@ -32,7 +32,7 @@ elif [ "$MACHINE" == "mac" ]; then
         export XDEBUG_HOST=$(ipconfig getifaddr en1) # Wifi
     fi
     SEDCMD="sed -i .bak"
-elif [ "$MACHINE" == "mingw64" ]; then
+elif [ "$MACHINE" == "mingw64" ]; then # Git Bash
     export XDEBUG_HOST=10.0.75.1
     SEDCMD="sed -i"
 fi


### PR DESCRIPTION
# Windows Support
There are (potentially) 3 ways Windows developers would access Vessel and/or Docker
1. MINGW64 - This includes Git Bash, Babun, Cygwin and direct MINGW64 installations
2. Windows Subsystem for Linux (WSL)
3. Native Windows - Command Prompt or Powershell

Since the Vessel script is written in bash the 3rd option is really it's own thing.  The first 2 options give us a bash shell (with other common GNU utils like sed) in which we can utilize the bash script.

## Notes on things added
* I didn't use Windows as a result of a detection because I figured this would be reserved for native windows support and I don't want to confuse people.  Instead the MINGW64 is being used.

* Using `$(uname -s)` on WSL will just return "Linux".  Because of this we need to add a detection method for WSL.  Fortunately the output of /proc/version differs as WSL adds Microsoft to their version name.  We can grep this output for Microsoft to determine it is WSL instead of a Linux OS.

## Differences between #20 and this PR
1. CHANGED The detection was listed as Windows10 but that can be confusing for people looking for native windows support.
2. REMOVED `COMPOSE_CONVERT_WINDOWS_PATHS=1` doesn't appear to be necessary.  The documentation only states Docker Toolbox (legacy) or docker-machine.
3. REMOVED `COMPOSE="winpty $COMPOSE"` While winpty is necessary in some cases but ONLY if you are using Mintty as the default terminal for Git Bash.  This choice is made during the installation of Git for Windows.  If you are using the standard command prompt this is not needed at all.  I haven't ran into any issues from the Vessel executing script using Mintty.  The only time I have had to use this is when I'm trying to log onto one of the containers interactively.  In this case it prompts me to try prefixing `winpty` in which I just do that and everything works.
4. ADDED `SEDCMD="sed -i"` under the MING64 detection.  It was missing from that PR and so the substitutions under Setting .env variables were not working correctly.

This script was tested on 2 different Windows machines; 1 domain joined laptop, and 1 custom desktop PC.  Both are running Windows 10 Pro, Version 1709 Build 162999.19 (Creators Update) 

Docker for Windows (Docker Community Edition) Version 17.09.0-ce-win33 (13620)

This PR would close #20 
