### PR TITLE
Updates Vessel to use newer IP command instead of IFCONFIG.

### DIFF
--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -18,7 +18,7 @@ fi
 
 # Set environment variables for dev
 if [ "$MACHINE" == "linux" ]; then
-    export XDEBUG_HOST=$(/sbin/ifconfig docker0 | grep "inet addr" | cut -d ':' -f 2 | cut -d ' ' -f 1)
+    export XDEBUG_HOST=$(ip address show docker0 | grep "inet" | gawk '{print $2}' | cut -d '/' -f 1)
     SEDCMD="sed -i"
 elif [ "$MACHINE" == "mac" ]; then
     export XDEBUG_HOST=$(ipconfig getifaddr en0) # Ethernet

--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -18,7 +18,7 @@ fi
 
 # Set environment variables for dev
 if [ "$MACHINE" == "linux" ]; then
-    export XDEBUG_HOST=$(ip address show docker0 | grep "inet" | gawk '{print $2}' | cut -d '/' -f 1)
+    export XDEBUG_HOST=$(ip -4 address show docker0 | grep "inet" | awk '{print $2}' | awk -F/ '{print $1}')
     SEDCMD="sed -i"
 elif [ "$MACHINE" == "mac" ]; then
     export XDEBUG_HOST=$(ipconfig getifaddr en0) # Ethernet


### PR DESCRIPTION
Many newer Linux systems are moving away from `ifconfig` in favor of newer `ip` command for networking functions.

This changes `XDEBUG_HOST` line to use this newer command.

Granted, I don't use XDEBUG, but it was causing the `command not found` error every time `vessel` is run.

Tested on OpenSUSE Tumbleweed only but `ip` is a pretty universal command.