### PR TITLE
Php7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ As mentioned, anything not recognized as a built-in command will be used as an a
 
 The aim of this project is simplicity. It includes:
 
-* PHP 7.1
+* PHP 7.2
 * MySQL 5.7
 * Redis ([latest](https://hub.docker.com/_/redis/))
 * NodeJS ([latest](https://hub.docker.com/_/node/)), with Yarn & Gulp

--- a/docker-files/docker/app/Dockerfile
+++ b/docker-files/docker/app/Dockerfile
@@ -18,15 +18,16 @@ RUN set -x \
     && gosu nobody true \
     && apt-get purge -y --auto-remove ca-certificates wget
 
+# Note: php7.2-xdebug not available yet!
 RUN echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu xenial main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && echo "deb http://ppa.launchpad.net/nginx/development/ubuntu xenial main" > /etc/apt/sources.list.d/ppa_nginx_mainline.list \
     && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E5267A6C \
     && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C300EE8C \
     && apt-get update \
     && apt-get install -y curl zip unzip git supervisor sqlite3 \
-    && apt-get install -y nginx php7.1-fpm php7.1-cli php7.1-mcrypt php7.1-gd php7.1-mysql \
-       php7.1-pgsql php7.1-imap php-memcached php7.1-mbstring php7.1-xml php7.1-curl \
-       php7.1-imagick php7.1-zip php7.1-bcmath php7.1-sqlite3 php7.1-xdebug \
+    && apt-get install -y nginx php7.2-fpm php7.2-cli php7.2-sodium php7.2-gd php7.2-mysql \
+       php7.2-pgsql php7.2-imap php7.2-memcached php7.2-mbstring php7.2-xml php7.2-curl \
+       php7.2-imagick php7.2-zip php7.2-bcmath php7.2-sqlite3 \
     && php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
     && mkdir /run/php \
     && apt-get -y autoremove \
@@ -39,8 +40,8 @@ RUN ln -sf /dev/stdout /var/log/nginx/access.log \
 
 COPY h5bp /etc/nginx/h5bp
 COPY default /etc/nginx/sites-available/default
-COPY php-fpm.conf /etc/php/7.1/fpm/php-fpm.conf
-COPY xdebug.ini /etc/php/7.1/mods-available/xdebug.ini
+COPY php-fpm.conf /etc/php/7.2/fpm/php-fpm.conf
+COPY xdebug.ini /etc/php/7.2/mods-available/xdebug.ini
 
 EXPOSE 80
 

--- a/docker-files/docker/app/Dockerfile
+++ b/docker-files/docker/app/Dockerfile
@@ -18,7 +18,6 @@ RUN set -x \
     && gosu nobody true \
     && apt-get purge -y --auto-remove ca-certificates wget
 
-# Note: php7.2-xdebug not available yet!
 RUN echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu xenial main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && echo "deb http://ppa.launchpad.net/nginx/development/ubuntu xenial main" > /etc/apt/sources.list.d/ppa_nginx_mainline.list \
     && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E5267A6C \
@@ -27,7 +26,7 @@ RUN echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu xenial main" > /etc/apt
     && apt-get install -y curl zip unzip git supervisor sqlite3 \
     && apt-get install -y nginx php7.2-fpm php7.2-cli php7.2-sodium php7.2-gd php7.2-mysql \
        php7.2-pgsql php7.2-imap php7.2-memcached php7.2-mbstring php7.2-xml php7.2-curl \
-       php7.2-imagick php7.2-zip php7.2-bcmath php7.2-sqlite3 \
+       php7.2-imagick php7.2-zip php7.2-bcmath php7.2-sqlite3 php7.2-xdebug \
     && php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
     && mkdir /run/php \
     && apt-get -y autoremove \

--- a/docker-files/docker/app/default
+++ b/docker-files/docker/app/default
@@ -21,7 +21,7 @@ server {
     location ~ \.php$ {
         add_header X-Served-By Vessel;
         include snippets/fastcgi-php.conf;
-        fastcgi_pass unix:/run/php/php7.1-fpm.sock;
+        fastcgi_pass unix:/run/php/php7.2-fpm.sock;
     }
 
     error_page 404 /index.php;

--- a/docker-files/docker/app/php-fpm.conf
+++ b/docker-files/docker/app/php-fpm.conf
@@ -14,11 +14,11 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = /run/php/php7.1-fpm.pid
+pid = /run/php/php7.2-fpm.pid
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written
-; in a local file.
+; into a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
 error_log = /proc/self/fd/2
@@ -61,7 +61,7 @@ error_log = /proc/self/fd/2
 ; Default Value: 0
 ;process_control_timeout = 0
 
-; The maximum number of processes FPM will fork. This has been design to control
+; The maximum number of processes FPM will fork. This has been designed to control
 ; the global number of processes when using dynamic PM within a lot of pools.
 ; Use it with caution.
 ; Note: A value of 0 indicates no limit
@@ -69,10 +69,10 @@ error_log = /proc/self/fd/2
 ; process.max = 128
 
 ; Specify the nice(2) priority to apply to the master process (only if set)
-; The value can vary from -19 (highest priority) to 20 (lower priority)
+; The value can vary from -19 (highest priority) to 20 (lowest priority)
 ; Note: - It will only work if the FPM master process is launched as root
 ;       - The pool process will inherit the master process priority
-;         unless it specified otherwise
+;         unless specified otherwise
 ; Default Value: no set
 ; process.priority = -19
 
@@ -99,8 +99,8 @@ daemonize = no
 ; Default Value: not set (auto detection)
 ;events.mechanism = epoll
 
-; When FPM is build with systemd integration, specify the interval,
-; in second, between health report notification to systemd.
+; When FPM is built with systemd integration, specify the interval,
+; in seconds, between health report notification to systemd.
 ; Set to 0 to disable.
 ; Available Units: s(econds), m(inutes), h(ours)
 ; Default Unit: seconds
@@ -122,7 +122,7 @@ daemonize = no
 ; Relative path can also be used. They will be prefixed by:
 ;  - the global prefix if it's been set (-p argument)
 ;  - /usr otherwise
-include=/etc/php/7.1/fpm/pool.d/*.conf
+include=/etc/php/7.2/fpm/pool.d/*.conf
 
 ; Clear environment in FPM workers. Prevents arbitrary environment variables from
 ; reaching FPM worker processes by clearing the environment in workers before env

--- a/docker-files/docker/app/start-container
+++ b/docker-files/docker/app/start-container
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-# Config /etc/php/7.1/mods-available/xdebug.ini
-sed -i "s/xdebug\.remote_host\=.*/xdebug\.remote_host\=$XDEBUG_HOST/g" /etc/php/7.1/mods-available/xdebug.ini
+# Config /etc/php/7.2/mods-available/xdebug.ini
+sed -i "s/xdebug\.remote_host\=.*/xdebug\.remote_host\=$XDEBUG_HOST/g" /etc/php/7.2/mods-available/xdebug.ini
 
 # Run PHP-FPM as current user
 if [ ! -z "$WWWUSER" ]; then
-    sed -i "s/user\ \=.*/user\ \= $WWWUSER/g" /etc/php/7.1/fpm/pool.d/www.conf
+    sed -i "s/user\ \=.*/user\ \= $WWWUSER/g" /etc/php/7.2/fpm/pool.d/www.conf
 
     # Set UID of user "vessel"
     usermod -u $WWWUSER vessel

--- a/docker-files/docker/app/supervisord.conf
+++ b/docker-files/docker/app/supervisord.conf
@@ -9,7 +9,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:php-fpm]
-command=php-fpm7.1
+command=php-fpm7.2
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
Title says it all!

1. mcrypt is replaced by sodium (mcrypt is now gone)
    * interestingly, installing `php7.2-sodium` creates an warning in PHP saying the module is loaded twice, as sodium is compiled into PHP from `ppa:ondrej/php`. Might be a bug from that repository.
2. xdebug is not yet built for php7.2.