### PR TITLE
Use ip addr if it exists, otherwise use ifconfig in path.

### DIFF
--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -22,7 +22,11 @@ if [ "$MACHINE" == "linux" ]; then
     if grep -q Microsoft /proc/version; then # WSL
         export XDEBUG_HOST=10.0.75.1
     else
-        export XDEBUG_HOST=$(/sbin/ifconfig docker0 | grep "inet addr" | cut -d ':' -f 2 | cut -d ' ' -f 1)
+        if [ "$(command -v ip)" ]; then
+            export XDEBUG_HOST=$(ip addr show docker0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)
+        else
+            export XDEBUG_HOST=$(ifconfig docker0 | grep "inet addr" | cut -d ':' -f 2 | cut -d ' ' -f 1)
+        fi
     fi
     SEDCMD="sed -i"
 elif [ "$MACHINE" == "mac" ]; then


### PR DESCRIPTION
Copy of Pull Request #42 but includes check for the existence of the ip command. I also removed the /sbin prefix from the ifconfig command, as I figured most installs would have ifconfig in path anyways. (My fresh install of Solus has ifconfig, but it is in /usr/bin/).