### PR TITLE
Add a tinker command

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Here's a list of built-in helpers you can use. Any command not defined in the `v
 ./vessel artisan <cmd>
 ./vessel art <cmd> # "art" is a shortcut to "artisan"
 
+# Run tinker REPL
+./vessel tinker # "tinker" is a shortcut for "artisan tinker"
+
 # Run phpunit tests
 ./vessel test
 

--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -164,6 +164,21 @@ if [ $# -gt 0 ]; then
                 ./vendor/bin/phpunit "$@"
         fi
 
+    # If "tinker" is used, drop into the REPL
+    # inside a new container
+    elif [ "$1" == "tinker" ] ; then
+        shift 1
+        if [ "$EXEC" == "yes" ]; then
+            $COMPOSE exec \
+                -u vessel \
+                app \
+                php artisan tinker
+        else
+            $COMPOSE run --rm \
+                app \
+                php artisan tinker
+        fi
+
     # If "npm" is used, run npm
     # from our node container
     elif [ "$1" == "npm" ]; then


### PR DESCRIPTION
Because I am a lazy developer and I keep manually modifying my install of [vessel](https://vessel.shippingdocker.com/) I figure I would offer this as a PR. Just a shortcut to run tinker with `./vessel tinker` instead of `./vessel art tinker`. 

That's right I saved you 3 characters, no need to thank me, just make sure you write long insightful PRs with those saved 3 characters in the future. 