### PR TITLE
Removing image option from buildable services

### DIFF
--- a/docker-files/docker-compose.yml
+++ b/docker-files/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     build:
       context: ./docker/app
       dockerfile: Dockerfile
-    image: vessel/app
     ports:
      - "${APP_PORT}:80"
     environment:
@@ -21,7 +20,6 @@ services:
       dockerfile: Dockerfile
       args:
         uid: "${WWWUSER}"
-    image: vessel/node
     user: node
     volumes:
      - .:/var/www/html


### PR DESCRIPTION
While this is a good option in some cases, it currently can lead into problems.

Right now if you use `vessel` into multiple projects, and customize the `Dockerfile` of one of the projects, it won't use it as the `image` name is shared, so it will always use the image from the first project you build.

Removing it will basically use the `Project Name` of the project, which is the folder name...

So now image names for the projects will be:

* vessel/app => project1_app
* vessel/node => project1_node
* vessel/app => project2_app
* vessel/node => project2_node