### PR TITLE
Avoid warning in mysqldump and use internal envs

### DIFF
--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -214,11 +214,11 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             $COMPOSE exec \
                 mysql \
-                mysqldump -u root -p$DB_PASSWORD --default-character-set=utf8mb4 $DB_DATABASE | grep -v "mysqldump: \[Warning\]"
+                bash -c 'MYSQL_PWD=$MYSQL_ROOT_PASSWORD mysqldump -u root --default-character-set=utf8mb4 $MYSQL_DATABASE'
         else
             $COMPOSE run --rm \
                 mysql \
-                mysqldump -h mysql -u root -p$DB_PASSWORD --default-character-set=utf8mb4 $DB_DATABASE | grep -v "mysqldump: \[Warning\]"
+                bash -c 'MYSQL_PWD=$MYSQL_ROOT_PASSWORD mysqldump -u root --default-character-set=utf8mb4 $MYSQL_DATABASE'
         fi
 
     # Else, pass-thru args to docker-compose


### PR DESCRIPTION
The current version is nice but maybe we can improve that with:

* Inject password via MYSQL_PWD instead of -p to avoid warning. Nicer than grep -v.
* Use interval env vars instead of inject then to avoid duplication. Lost customization but centralize configuration in the container.