### PR TITLE
Fixed docker-compse default override behaviour

### DIFF
--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -54,7 +54,7 @@ else
 fi
 
 # Create base docker-compose command to run
-COMPOSE="docker-compose -f docker-compose.yml"
+COMPOSE="docker-compose"
 
 # If we pass any arguments...
 if [ $# -gt 0 ]; then


### PR DESCRIPTION
vessel is not able to use default docker-compose.override.yml due to  -f docker-compose.yml