### PR TITLE
using cloudflare DNS in /etc/resolv.conf

### DIFF
--- a/docker-files/docker/app/Dockerfile
+++ b/docker-files/docker/app/Dockerfile
@@ -45,6 +45,7 @@ COPY h5bp /etc/nginx/h5bp
 COPY default /etc/nginx/sites-available/default
 COPY php-fpm.conf /etc/php/7.2/fpm/php-fpm.conf
 COPY xdebug.ini /etc/php/7.2/mods-available/xdebug.ini
+COPY resolv.conf /etc/resolv.conf
 
 EXPOSE 80
 

--- a/docker-files/docker/app/resolv.conf
+++ b/docker-files/docker/app/resolv.conf
@@ -1,0 +1,2 @@
+nameserver 1.1.1.1
+options ndots:0


### PR DESCRIPTION
using cloudflare DNS in /etc/resolv.conf to help with php function `dns_get_record()`, which would fail when using `DNS_ALL` or `DNS_ANY` when attempting to get ipv6 addresses.

See [here](https://github.com/laravel/homestead/issues/409) for some more information on why this is likely resulted in a `Warning: dns_get_record(): A temporary server error occurred.` error before this change.