### PR TITLE
Maintain 200 status on 404

### DIFF
--- a/docker-files/docker/app/default
+++ b/docker-files/docker/app/default
@@ -26,7 +26,7 @@ server {
         fastcgi_pass unix:/run/php/php7.2-fpm.sock;
     }
 
-    error_page 404 /index.php;
+    error_page 404 =200 /index.php;
 
     location ~ /\.ht {
         deny all;


### PR DESCRIPTION
## Maintain HTTP status as 200 when erroring on 404 when PHP could still find the resource.

A case happened today while using [L5 Swagger's API Documentation](https://github.com/DarkaOnLine/L5-Swagger) which loads assets dynamically, building asset path and then routing via Laravel to the file itself.

Test case:
- Create project
- Add L5 Swagger and set it up as basic install steps describe
- Visit `/api/documentation` and get 404 on styles and scripts

Unfortunately, since we have static files served first, we don't actually find the file therefore falling into a 404 status code. The current error setup brings allows us to still resolve in Laravel.

Since the assets are found after that, we still have a 404 status this time with the content. So it's basically not found, but found.

Erroring and maintaining 200 as status code allows us to leverage Laravel headers for the correct status, which is not forced to 200 if the content is found in the internal redirects, but it is set to 404 on an actual 404.