### PR TITLE
Added configuration for enabling G-Zip on the App server

### DIFF
--- a/docker-files/docker/app/Dockerfile
+++ b/docker-files/docker/app/Dockerfile
@@ -35,8 +35,8 @@ RUN echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu bionic main" > /etc/apt
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log
 
-COPY h5bp /etc/nginx/h5bp
 COPY default /etc/nginx/sites-available/default
+COPY h5bp /etc/nginx/h5bp
 COPY php-fpm.conf /etc/php/7.3/fpm/php-fpm.conf
 COPY xdebug.ini /etc/php/7.3/mods-available/xdebug.ini
 COPY vessel.ini /etc/php/7.3/fpm/conf.d/99-vessel.ini

--- a/docker-files/docker/app/Dockerfile
+++ b/docker-files/docker/app/Dockerfile
@@ -35,8 +35,8 @@ RUN echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu bionic main" > /etc/apt
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log
 
-COPY default /etc/nginx/sites-available/default
 COPY h5bp /etc/nginx/h5bp
+COPY default /etc/nginx/sites-available/default
 COPY php-fpm.conf /etc/php/7.3/fpm/php-fpm.conf
 COPY xdebug.ini /etc/php/7.3/mods-available/xdebug.ini
 COPY vessel.ini /etc/php/7.3/fpm/conf.d/99-vessel.ini

--- a/docker-files/docker/app/h5bp/basic.conf
+++ b/docker-files/docker/app/h5bp/basic.conf
@@ -1,5 +1,6 @@
 # Basic h5bp rules
 
+include h5bp/directive-only/gzip.conf;
 include h5bp/directive-only/x-ua-compatible.conf;
 include h5bp/location/expires.conf;
 include h5bp/location/cross-domain-fonts.conf;

--- a/docker-files/docker/app/h5bp/directive-only/gzip.conf
+++ b/docker-files/docker/app/h5bp/directive-only/gzip.conf
@@ -1,0 +1,61 @@
+  # This Config is based on the following two pages:
+  # https://leaderinternet.com/blog/enable-compression-laravel-forge
+  # https://mattstauffer.com/blog/enabling-gzip-on-nginx-servers-including-laravel-forge/
+
+  
+  # Enable gzip compression.
+  # Default: off
+  gzip on;
+
+  # Compression level (1-9).
+  # 5 is a perfect compromise between size and CPU usage, offering about
+  # 75% reduction for most ASCII files (almost identical to level 9).
+  # Default: 1
+  gzip_comp_level    5;
+
+  # Don't compress anything that's already small and unlikely to shrink much
+  # if at all (the default is 20 bytes, which is bad as that usually leads to
+  # larger files after gzipping).
+  # Default: 20
+  gzip_min_length    256;
+
+  # Compress data even for clients that are connecting to us via proxies,
+  # identified by the "Via" header (required for CloudFront).
+  # Default: off
+  gzip_proxied       any;
+
+  # Tell proxies to cache both the gzipped and regular version of a resource
+  # whenever the client's Accept-Encoding capabilities header varies;
+  # Avoids the issue where a non-gzip capable client (which is extremely rare
+  # today) would display gibberish if their proxy gave them the gzipped version.
+  # Default: off
+  gzip_vary          on;
+
+  # Compress all output labeled with one of the following MIME-types.
+  # text/html is always compressed by gzip module.
+  # Default: text/html
+  gzip_types
+    application/atom+xml
+    application/javascript
+    application/json
+    application/ld+json
+    application/manifest+json
+    application/rss+xml
+    application/vnd.geo+json
+    application/vnd.ms-fontobject
+    application/x-font-ttf
+    application/x-web-app-manifest+json
+    application/xhtml+xml
+    application/xml
+    font/opentype
+    image/bmp
+    image/svg+xml
+    image/x-icon
+    text/cache-manifest
+    text/css
+    text/plain
+    text/vcard
+    text/vnd.rim.location.xloc
+    text/vtt
+    text/x-component
+    text/x-cross-domain-policy;


### PR DESCRIPTION
We found that having G-Zip Enabled on the App Server, especially for the API, increased the speed of our Application many-fold.
Here's hoping it can be useful to others.