### PR TITLE
Tweaks to keyserver for firewall issues

### DIFF
--- a/docker-files/docker/app/Dockerfile
+++ b/docker-files/docker/app/Dockerfile
@@ -14,8 +14,8 @@ RUN set -x \
 
 RUN echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu bionic main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && echo "deb http://ppa.launchpad.net/nginx/development/ubuntu bionic main" > /etc/apt/sources.list.d/ppa_nginx_mainline.list \
-    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E5267A6C \
-    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C300EE8C \
+    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E5267A6C \
+    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C300EE8C \
     && apt-get update \
     && apt-get install -y curl zip unzip git supervisor sqlite3 \
     && apt-get install -y nginx php7.3-fpm php7.3-cli \


### PR DESCRIPTION
Some users (not myself) have expressed issues with port `11371` being blocked by company firewalls. This forces it to use port `80` instead, bypassing these firewall issues.