### PR TITLE
Fix Debug From CLI Error

### DIFF
--- a/docker-files/docker-compose.yml
+++ b/docker-files/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       CONTAINER_ENV: "${APP_ENV}"
       XDEBUG_HOST: "${XDEBUG_HOST}"
       WWWUSER: "${WWWUSER}"
+      PHP_IDE_CONFIG: "${PHP_IDE_CONFIG}"
     volumes:
      - .:/var/www/html
     networks:

--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -44,6 +44,7 @@ fi
 export APP_PORT=${APP_PORT:-80}
 export MYSQL_PORT=${MYSQL_PORT:-3306}
 export WWWUSER=${WWWUSER:-$UID}
+export PHP_IDE_CONFIG=${PHP_IDE_CONFIG:-'serverName=_'}
 
 # Is the environment running
 PSRESULT="$(docker-compose ps -q)"


### PR DESCRIPTION
**Problem:**
Currently, once the debug is set in IDE, and path mappings are defined, debugging works fine and will not generate any error/warning if server is accessed from browser.
_But_ if user wants to debug anything from CLI (e.g. run any artisan command), current setup generates an error and does not cater earlier defined path mappings.

![screenshot 2019-02-20 at 10 19 52 am](https://user-images.githubusercontent.com/3117493/53068698-327d0300-34fb-11e9-9d9b-b7aa99387ea4.png)


**Solution**
To resolve this issue, an environment variable needs to be set.
The changes done allow user to define the variable in their .env file. If the variable is not defined, it will set the default server value which is already there in Default conf file of nginx in Vessel.
https://github.com/shipping-docker/vessel/blob/65cf285a5647f7593d49f8da665ac1399b904c80/docker-files/docker/app/default#L8
https://www.jetbrains.com/help/phpstorm/debugging-a-php-cli-script.html

**Suggestion**
If we think it is IDE specific and should not be there in the package, maybe it can be added in Wiki and linked in the docs.