### PR TITLE
106/add-help-interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .DS_Store
+.vscode/
+.idea/
 vendor/
 composer.lock

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Head to `http://localhost` in your browser and see your Laravel site!
 If you're using Lumen, you'll need to copy the Vessel files over manually instead of using `php artisan vendor:publish`. You can do this with this command:
 
     cp -R vendor/shipping-docker/vessel/docker-files/{vessel,docker-compose.yml,docker} .
-    
+
 and then you'll be able to install and continue as normal.
-    
-    
+
+
 ## Multiple Environments
 
 Vessel attempts to bind to port 80 and 3306 on your machine, so you can simply go to `http://localhost` in your browser.
@@ -68,6 +68,16 @@ The password for user `root` is set by environment variable `DB_PASSWORD` from w
 ## Common Commands
 
 Here's a list of built-in helpers you can use. Any command not defined in the `vessel` script will default to being passed to the `docker-compose` command. If not command is used, it will run `docker-compose ps` to list the running containers for this environment.
+
+### Show Vessel Version or Help
+
+```bash
+# shows vessel current version
+$ vessel --version # or [ -v | version ]
+
+# shows vessel help
+$ vessel --help # or [ -H | help ]
+```
 
 ### Starting and Stopping Vessel
 
@@ -148,7 +158,7 @@ As mentioned, anything not recognized as a built-in command will be used as an a
 
 # Start a bash shell inside of a container
 # This is just like SSH'ing into a server
-# Note that changes to a container made this way will **NOT** 
+# Note that changes to a container made this way will **NOT**
 #   survive through stopping and starting the vessel environment
 #   To install software or change server configuration, you'll need to
 #     edit the Dockerfile and run: ./vessel build
@@ -185,8 +195,8 @@ Vessel requires Docker, and currently only works on Windows, Mac and Linux.
 > Windows requires running Hyper-V.  Using Git Bash (MINGW64) and WSL are supported.  Native
   Windows is still under development.
 
-| Mac           | Linux         | Windows |
-| ------------- |:-------------:|:-------:|
+| Mac                                                                      |                                              Linux                                              |                                     Windows                                      |
+| ------------------------------------------------------------------------ | :---------------------------------------------------------------------------------------------: | :------------------------------------------------------------------------------: |
 | Install Docker on [Mac](https://docs.docker.com/docker-for-mac/install/) | Install Docker on [Debian](https://docs.docker.com/engine/installation/linux/docker-ce/debian/) | Install Docker on [Windows](https://docs.docker.com/docker-for-windows/install/) |
-|       | Install Docker on [Ubuntu](https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/) | |
-|       | Install Docker on [CentOS](https://docs.docker.com/engine/installation/linux/docker-ce/centos/) | |
+|                                                                          | Install Docker on [Ubuntu](https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/) |                                                                                  |
+|                                                                          | Install Docker on [CentOS](https://docs.docker.com/engine/installation/linux/docker-ce/centos/) |                                                                                  |

--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -1,5 +1,21 @@
 #!/usr/bin/env bash
 
+VERSION="4.0.2" # bumped to support vessel --help, vessel --version
+
+# define colors that are used in the help screen
+
+ESC_SEQ="\x1b["
+COL_RESET=${ESC_SEQ}"39;49;00m"
+COL_LYELLOW=${ESC_SEQ}"33;01m"
+COL_LGREEN=${ESC_SEQ}"32;01m"
+COL_CYAN=${ESC_SEQ}"0;36m"
+COL_GREEN=${ESC_SEQ}"0;32m"
+COL_MAGENTA=${ESC_SEQ}"0;35m"
+
+CONTAINER_APP="app"
+CONTAINER_MYSQL="mysql"
+CONTAINER_NODE="node"
+
 UNAMEOUT="$(uname -s)"
 case "${UNAMEOUT}" in
     Linux*)             MACHINE=linux;;
@@ -45,6 +61,62 @@ export APP_PORT=${APP_PORT:-80}
 export MYSQL_PORT=${MYSQL_PORT:-3306}
 export WWWUSER=${WWWUSER:-$UID}
 
+showVersion() {
+    intro="\n🐳 ${COL_GREEN}Vessel for Docker${COL_RESET}\n"
+    intro="$intro   ${COL_CYAN}Version ${VERSION}\n${COL_RESET}"
+
+    printf "$intro"
+}
+
+showHelp() {
+
+    showVersion
+
+    usage="${COL_LYELLOW}Usage:\n${COL_RESET}"
+    usage="$usage  ./vessel <cmd> <options>"
+
+    commands="${COL_LYELLOW}Commands:\n${COL_RESET}"
+    commands="$commands  art | artisan <cmd>         Run Laravel Artisan CLI in ${COL_MAGENTA}${CONTAINER_APP}${COL_RESET} container\n"
+    commands="$commands  composer <cmds>             Run Composer in ${COL_MAGENTA}${CONTAINER_APP}${COL_RESET} container\n"
+    commands="$commands  mysql                       Run MySQL CLI in ${COL_MAGENTA}${CONTAINER_MYSQL}${COL_RESET} container\n"
+    commands="$commands  dump (autoload)             Performs composer dump-autoload in ${COL_MAGENTA}${CONTAINER_APP}${COL_RESET} container\n"
+    commands="$commands  exec <container>            Execute a command in a running container\n"
+    commands="$commands  help                        Shows Help screen\n"
+    commands="$commands  logs <container> < -f >     Displays all logs for <container> and optionally tail\n"
+    commands="$commands  npm                         Execute npm command using ${COL_MAGENTA}${CONTAINER_NODE}${COL_RESET} container\n"
+    commands="$commands  ps                          Display list of all running containers in current directory\n"
+    commands="$commands  start < -l >                Starts all containers defined in ${COL_LGREEN}docker-compose.yml${COL_RESET} file\n"
+    commands="$commands  stop                        Stops all containers defined in ${COL_LGREEN}docker-compose.yml${COL_RESET} file\n"
+    commands="$commands  test [params]               Runs PHPUnit using supplied options in ${COL_MAGENTA}${CONTAINER_APP}${COL_RESET} container\n"
+    commands="$commands  tinker                      Runs Tinker in ${COL_MAGENTA}${CONTAINER_APP}${COL_RESET} container\n"
+    commands="$commands  npm <options>               Runs npm using supplied options in ${COL_MAGENTA}${CONTAINER_NODE}${COL_RESET} container\n"
+    commands="$commands  yarn <options>              Runs yarn using supplied options in ${COL_MAGENTA}${CONTAINER_NODE}${COL_RESET} container\n"
+#    commands="$commands  gulp <task>                 Runs gulp task in ${COL_MAGENTA}${CONTAINER_NODE}${COL_RESET} container\n"
+
+    options="${COL_LYELLOW}Options:\n${COL_RESET}"
+    options="$options --help, -h                   Shows Help (this screen)\n"
+#    options="$options --logs, -l                   Run containers in detached mode (with logging)\n"
+    options="$options --version, -V, version       Show Version\n"
+
+    examples="${COL_LYELLOW}Examples:\n${COL_RESET}"
+    examples="$examples  ${COL_CYAN}$ ./vessel start${COL_RESET}\n"
+    examples="$examples  ${COL_CYAN}$ ./vessel stop${COL_RESET}\n"
+    examples="$examples  ${COL_CYAN}$ ./vessel dump${COL_RESET}\n"
+    examples="$examples  ${COL_CYAN}$ ./vessel logs # all container logs${COL_RESET}\n"
+    examples="$examples  ${COL_CYAN}$ ./vessel composer require <vendor/package>${COL_RESET}\n"
+    examples="$examples  ${COL_CYAN}$ ./vessel mysql${COL_RESET}\n"
+    examples="$examples  ${COL_CYAN}$ ./vessel artisan migrate --seed${COL_RESET}\n"
+    examples="$examples  ${COL_CYAN}$ ./vessel art db:seed${COL_RESET}\n"
+    examples="$examples  ${COL_CYAN}$ ./vessel test --filter=MyFilter${COL_RESET}\n"
+
+    printf "\n"
+    printf "$usage\n\n"
+    printf "$commands\n"
+    printf "$options\n"
+    printf "$examples\n"
+
+}
+
 # Is the environment running
 PSRESULT="$(docker-compose ps -q)"
 if [ ! -z "$PSRESULT" ]; then
@@ -63,6 +135,16 @@ if [ $# -gt 0 ]; then
     # such as APP_PORT, MYSQL_PORT, and WWWUSER
     if [ -f .env ]; then
         source .env
+    fi
+
+
+    if [ "$1" == "--version" ] || [ "$1" == "-v" ] || [ "$1" == "version" ]; then
+        showVersion
+        exit 1
+    fi
+    if [ "$1" == "--help" ] || [ "$1" == "-H" ] || [ "$1" == "help" ]; then
+        showHelp
+        exit 1
     fi
 
 
@@ -302,3 +384,5 @@ else
     # Use the docker-compose ps command if nothing else passed through
     $COMPOSE ps
 fi
+
+


### PR DESCRIPTION
Add help interface to vessel CLI

```bash
$ vessel help 
$ vessel --help
$ vessel -H
```

In addition, added new version variable to allow tracking easier and support version command from CLI

```bash
$ vessel version
$ vessel --version
$ vessel -v
````