### PR TITLE
An optional option to optionally add your composer config

### DIFF
--- a/docker-files/docker-compose.yml
+++ b/docker-files/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       WWWUSER: "${WWWUSER}"
     volumes:
      - .:/var/www/html
+#     - ${COMPOSER_HOME-~/.composer}:/root/.composer
     networks:
      - vessel
   node:


### PR DESCRIPTION
An optional option to optionally add your composer config, which will prevent the need from creating Github API access tokens when doing a lot of composer work.