### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-files/docker-compose.yml
+++ b/docker-files/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       MYSQL_DATABASE: "${DB_DATABASE}"
       MYSQL_USER: "${DB_USERNAME}"
       MYSQL_PASSWORD: "${DB_PASSWORD}"
-      # MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
     volumes:
      - vesselmysql:/var/lib/mysql
      # - ./docker/mysql/conf.d:/etc/mysql/conf.d

--- a/docker-files/docker-compose.yml
+++ b/docker-files/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       MYSQL_DATABASE: "${DB_DATABASE}"
       MYSQL_USER: "${DB_USERNAME}"
       MYSQL_PASSWORD: "${DB_PASSWORD}"
+      # MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
     volumes:
      - vesselmysql:/var/lib/mysql
      # - ./docker/mysql/conf.d:/etc/mysql/conf.d


### PR DESCRIPTION
Hi @fideloper,

I have just started using Vessel today and upon running `./vessel start` MySQL container immediately exited with status `Exit (1)`. It took me some time to find the issue in the first place as well as coming up with the right syntax. 

I have added a commented out line for `MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'` to the default `docker-compose.yml` file. As Laravel uses this by default on a new `.env` file, I thought it useful for newcomers and gives them the solution right there.

Furthermore, as you have referenced this as [an issue](https://github.com/shipping-docker/vessel-docs/issues/9) a while back, I'm willing to lend a hand with the documentation, if you find you need any help. If you merge this option, I can update the docs accordingly. Let me know.

Kind regards,
g