### PR TITLE
Don't replace commented DB_HOST on my .env

### DIFF
--- a/docker-files/vessel
+++ b/docker-files/vessel
@@ -173,8 +173,8 @@ if [ $# -gt 0 ]; then
         echo "VESSEL: Setting .env Variables"
         cp .env .env.bak.vessel
 
-        if [ ! -z "$(grep "DB_HOST" .env)" ]; then
-            $SEDCMD "s/DB_HOST=.*/DB_HOST=mysql/" .env
+        if [ ! -z "$(grep "^DB_HOST" .env)" ]; then
+            $SEDCMD "s/^DB_HOST=.*/DB_HOST=mysql/" .env
         else
             echo "DB_HOST=mysql" >> .env
         fi


### PR DESCRIPTION
I lost my commented line for alternative DB host :-(
I think it's better to replace active DB_HOST line only.