### PR TITLE
Support for Websocket Laravel Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,12 @@ As mentioned, anything not recognized as a built-in command will be used as an a
 ./vessel exec mysql mysqldump -u root -psecret homestead > homestead.sql
 ```
 
+## Websockets Laravel
+
+Usage:
+
+* First install Websockets Library from its documentation and configure
+* Configure .env file: WEBSOCKETS='your-port', this port will be binded to 6001 port on container.
 
 ## What's included?
 

--- a/docker-files/docker-compose.yml
+++ b/docker-files/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     image: vessel/app
     ports:
      - "${APP_PORT}:80"
+     - "${WEBSOCKET_PORT}:6001"
     environment:
       CONTAINER_ENV: "${APP_ENV}"
       XDEBUG_HOST: "${XDEBUG_HOST}"

--- a/docker-files/docker/app/Dockerfile
+++ b/docker-files/docker/app/Dockerfile
@@ -47,6 +47,7 @@ COPY xdebug.ini /etc/php/7.3/mods-available/xdebug.ini
 COPY vessel.ini /etc/php/7.3/fpm/conf.d/99-vessel.ini
 
 EXPOSE 80
+EXPOSE 6001
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY start-container /usr/local/bin/start-container

--- a/docker-files/docker/app/supervisord.conf
+++ b/docker-files/docker/app/supervisord.conf
@@ -14,3 +14,10 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:websockets]
+command=php /var/www/html/artisan websockets:serve
+numprocs=1
+autostart=true
+autorestart=true
+user=vessel


### PR DESCRIPTION
This new PR supports laravel websockets running on same container to have a good integration with websockets Library, it runs on PORT 6001 and works only installing its library.