### PR TITLE
Install Vessel as a Composer Development Requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Vessel is just a small set of files that sets up a local Docker-based dev enviro
 This is all there is to using it:
 
 ```bash
-composer require shipping-docker/vessel
+composer require --dev shipping-docker/vessel
 php artisan vendor:publish --provider="Vessel\VesselServiceProvider"
 
 # Run this once to initialize project


### PR DESCRIPTION
This will prevent people from shipping the dependency to production when they run `composer install --no-dev`.