### PR TITLE
Append PHP version on  Redis php extension

### DIFF
--- a/docker-files/docker/app/Dockerfile
+++ b/docker-files/docker/app/Dockerfile
@@ -25,7 +25,7 @@ RUN echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu bionic main" > /etc/apt
        php7.3-xml php7.3-zip php7.3-bcmath php7.3-soap \
        php7.3-intl php7.3-readline php7.3-xdebug \
        php7.3-msgpack php7.3-igbinary php7.3-ldap \
-       php-redis \
+       php7.3-redis \
     && php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
     && mkdir /run/php \
     && apt-get -y autoremove \


### PR DESCRIPTION
Hi,

I've worked on a project that used, this docker environement, but I found an issue when I build.

The version of the php-redis extension is missing so it install php8.1 instead of php7.3